### PR TITLE
[Addition] Add missing island and map number of artifacts per island

### DIFF
--- a/definitions/misc/world5/IslandInfo.py
+++ b/definitions/misc/world5/IslandInfo.py
@@ -12,3 +12,4 @@ class IslandInfo(IdleonModel):
 	cloudsUnlocked: Numeric
 	xYPointer: str
 	expPerTrip: int
+	artifactsPerIsland: int

--- a/exported/ts/data/IslandInfoRepo.ts
+++ b/exported/ts/data/IslandInfoRepo.ts
@@ -15,7 +15,8 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 10,
                 "cloudsUnlocked": 1.2,
                 "xYPointer": "0,0",
-                "expPerTrip": 2
+                "expPerTrip": 2,
+                "artifactsPerIsland": 4
             }),
         new IslandInfoBase(1, <IslandInfoModel>{
                 "name": "Beachy Coast",
@@ -26,7 +27,8 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 200,
                 "cloudsUnlocked": 3.5,
                 "xYPointer": "43,304",
-                "expPerTrip": 6
+                "expPerTrip": 6,
+                "artifactsPerIsland": 3
             }),
         new IslandInfoBase(2, <IslandInfoModel>{
                 "name": "Isolated Woods",
@@ -37,7 +39,8 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 800,
                 "cloudsUnlocked": -1,
                 "xYPointer": "398,206",
-                "expPerTrip": 10
+                "expPerTrip": 10,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(3, <IslandInfoModel>{
                 "name": "Rocky Peaks",
@@ -48,7 +51,8 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 6000,
                 "cloudsUnlocked": 5,
                 "xYPointer": "271,340",
-                "expPerTrip": 20
+                "expPerTrip": 20,
+                "artifactsPerIsland": 3
             }),
         new IslandInfoBase(4, <IslandInfoModel>{
                 "name": "Stormy North",
@@ -59,10 +63,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 30000,
                 "cloudsUnlocked": 1,
                 "xYPointer": "426,69",
-                "expPerTrip": 30
+                "expPerTrip": 30,
+                "artifactsPerIsland": 3
             }),
         new IslandInfoBase(5, <IslandInfoModel>{
-                "name": "Toxic Bay Inc",
+                "name": "Snowy South",
                 "distance": 10000,
                 "relic1": 0,
                 "relic2": -1,
@@ -70,10 +75,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 120000,
                 "cloudsUnlocked": 7,
                 "xYPointer": "190,426",
-                "expPerTrip": 55
+                "expPerTrip": 55,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(6, <IslandInfoModel>{
-                "name": "Candied Island",
+                "name": "Toxic Bay Inc",
                 "distance": 25000,
                 "relic1": 0,
                 "relic2": -1,
@@ -81,10 +87,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 400000,
                 "cloudsUnlocked": 7.8,
                 "xYPointer": "479,309",
-                "expPerTrip": 85
+                "expPerTrip": 85,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(7, <IslandInfoModel>{
-                "name": "Fungi Meadows",
+                "name": "Candied Island",
                 "distance": 100000,
                 "relic1": 0,
                 "relic2": -1,
@@ -92,10 +99,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 2000000,
                 "cloudsUnlocked": 10,
                 "xYPointer": "379,404",
-                "expPerTrip": 150
+                "expPerTrip": 150,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(8, <IslandInfoModel>{
-                "name": "Cloudy Quay",
+                "name": "Fungi Meadows",
                 "distance": 300000,
                 "relic1": 0,
                 "relic2": -1,
@@ -103,10 +111,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 8000000,
                 "cloudsUnlocked": 9.11,
                 "xYPointer": "625,219",
-                "expPerTrip": 300
+                "expPerTrip": 300,
+                "artifactsPerIsland": 1
             }),
         new IslandInfoBase(9, <IslandInfoModel>{
-                "name": "Dungeon Cove",
+                "name": "Cloudy Quay",
                 "distance": 1000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -114,10 +123,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 30000000,
                 "cloudsUnlocked": 12,
                 "xYPointer": "635,113",
-                "expPerTrip": 600
+                "expPerTrip": 600,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(10, <IslandInfoModel>{
-                "name": "Crystal Enclave",
+                "name": "Dungeon Cove",
                 "distance": 2000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -125,10 +135,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 60000000,
                 "cloudsUnlocked": 1,
                 "xYPointer": "542,426",
-                "expPerTrip": 900
+                "expPerTrip": 900,
+                "artifactsPerIsland": 1
             }),
         new IslandInfoBase(11, <IslandInfoModel>{
-                "name": "Petulent Garage",
+                "name": "Crystal Enclave",
                 "distance": 5000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -136,10 +147,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 120000000,
                 "cloudsUnlocked": 1,
                 "xYPointer": "645,354",
-                "expPerTrip": 1500
+                "expPerTrip": 1500,
+                "artifactsPerIsland": 1
             }),
         new IslandInfoBase(12, <IslandInfoModel>{
-                "name": "Isle of Note",
+                "name": "Petulent Garage",
                 "distance": 15000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -147,10 +159,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 400000000,
                 "cloudsUnlocked": 13,
                 "xYPointer": "826,74",
-                "expPerTrip": 3000
+                "expPerTrip": 3000,
+                "artifactsPerIsland": 1
             }),
         new IslandInfoBase(13, <IslandInfoModel>{
-                "name": "The Edge",
+                "name": "Isle of Note",
                 "distance": 40000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -158,10 +171,11 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 1200000000,
                 "cloudsUnlocked": 14,
                 "xYPointer": "840,243",
-                "expPerTrip": 5000
+                "expPerTrip": 5000,
+                "artifactsPerIsland": 2
             }),
         new IslandInfoBase(14, <IslandInfoModel>{
-                "name": "Sahara",
+                "name": "The Edge",
                 "distance": 100000000,
                 "relic1": 0,
                 "relic2": -1,
@@ -169,7 +183,8 @@ export const initIslandInfoRepo = () => {
                 "unlockQty": 2000000000,
                 "cloudsUnlocked": 1,
                 "xYPointer": "764,426",
-                "expPerTrip": 10000
+                "expPerTrip": 10000,
+                "artifactsPerIsland": 1
             })    
 ]
 }

--- a/exported/ts/model/islandInfoModel.ts
+++ b/exported/ts/model/islandInfoModel.ts
@@ -9,5 +9,6 @@ export interface IslandInfoModel {
     unlockQty: number,
     cloudsUnlocked: number,
     xYPointer: string,
-    expPerTrip: number
+    expPerTrip: number,
+    artifactsPerIsland: number
 }

--- a/helpers/Constants.py
+++ b/helpers/Constants.py
@@ -43,6 +43,6 @@ class Constants:
 	             "Cosmic Carrier"]
 	stampTypes = ["Combat Stamp", "Skills Stamp", "Misc Stamp"]
 
-	sailingIslands = ["Safari Island", "Beachy Coast", "Isolated Woods", "Rocky Peaks", "Stormy North",
-	                  "Toxic Bay Inc", "Candied Island", "Fungi Meadows", "Cloudy Quay", "Dungeon Cove",
+	sailingIslands = ["Safari Island", "Beachy Coast", "Isolated Woods", "Rocky Peaks", "Stormy North", 
+	                  "Snowy South", "Toxic Bay Inc", "Candied Island", "Fungi Meadows", "Cloudy Quay", "Dungeon Cove",
 	                  "Crystal Enclave", "Petulent Garage", "Isle of Note", "The Edge"]

--- a/repositories/misc/world5/IslandInfoRepo.py
+++ b/repositories/misc/world5/IslandInfoRepo.py
@@ -2,7 +2,7 @@ from typing import List
 
 from definitions.misc.world5.IslandInfo import IslandInfo
 from helpers.Constants import Constants
-from helpers.HelperFunctions import getFromSplitArray
+from helpers.HelperFunctions import getFromSplitArray, getFromArrayArray
 from repositories.master.Repository import Repository
 
 
@@ -14,14 +14,18 @@ class IslandInfoRepo(Repository[IslandInfo]):
 
 	@classmethod
 	def getSections(cls) -> List[str]:
-		return ["IslandInfo"]
+		return ["IslandInfo", "IslandInfobox"]
 
 	@classmethod
 	def generateRepo(cls) -> None:
 		data = getFromSplitArray(cls.getSection())
+		boxInfo = getFromArrayArray(cls.getSection(1));
 		for n, line in enumerate(data):
 			if n < len(Constants.sailingIslands):
 				line[0] = Constants.sailingIslands[n]
+
+			# Second index of box info has number of artifacts
+			line.append(boxInfo[n][2])
 			cls.addList(IslandInfo.fromList(line))
 			if cls.contains(line[0]): continue
 			cls.add(line[0], IslandInfo.fromList(line))


### PR DESCRIPTION
## Overview

* The `Snowy South` island was missed during the original generation of the islands
* Add the number of artifacts per island from the `IslandInfobox` section